### PR TITLE
Added api_key to pass on session creation and check instead of user_id

### DIFF
--- a/app/assets/javascripts/controllers/userController.js.coffee
+++ b/app/assets/javascripts/controllers/userController.js.coffee
@@ -1,5 +1,7 @@
 YJ.userController = Em.Object.create(
   currentUser: null
+  api_key: null
+
 
   authenticate: ->
     #make a call to the server to find user with email/password
@@ -12,7 +14,9 @@ YJ.userController = Em.Object.create(
       data: {email: @currentUser.get('email'), password: @currentUser.get('password')}
       dataType: 'json'
       success: (data) ->
+        console.log(data)
         self.currentUser.update(data.user)
+        self.set('api_key', data.api_key)
         true
 
       failure:
@@ -30,6 +34,7 @@ YJ.userController = Em.Object.create(
       dataType: 'json'
       success: (data) ->
         self.currentUser.update(data.user)
+        #TODO.  Redirect the user to sign in and create a session
         true
 
       failure: ->

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,17 +13,17 @@ class ApplicationController < ActionController::Base
   def current_user
      return @current_user if @current_user
 
-     if session[:user_id]
-       @current_user = User.find_by_id(session[:user_id])
+     if session[:api_key]
+       @current_user = User.find_by_api_key(session[:api_key])
      end
   end
 
   def create_user_session(user)
-    session[:user_id] = user.id
+    session[:api_key] = user.api_key
   end
 
   def destroy_user_session
-    session[:user_id] = nil
+    session[:api_key] = nil
   end
 
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@ class SessionsController < ApplicationController
 
       if @user
         create_user_session(@user)
-        render :json => @user
+        render :json => {:user => UserSerializer.new(@user).as_json[:user], :api_key => @user.api_key}
       else
         respond_with "invalid email or password"
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ActiveRecord::Base
 
    validates :email, :presence => true, :uniqueness => true
 
+   after_create :api_authenticable
 
    def password=(pass)
      return if pass.blank?
@@ -16,5 +17,11 @@ class User < ActiveRecord::Base
    def self.authenticate(email, password)
      user = find_by_email(email)
      user && BCrypt::Password.new(user.password_digest) == password ? user : nil
+   end
+
+   private
+
+   def api_authenticable
+     update_attribute(:api_key, Digest::SHA1.hexdigest([Time.now, rand].join))
    end
 end

--- a/db/migrate/20120516170738_add_api_key_to_user.rb
+++ b/db/migrate/20120516170738_add_api_key_to_user.rb
@@ -1,0 +1,5 @@
+class AddApiKeyToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :api_key, :string
+  end
+end


### PR DESCRIPTION
I added an automatic generation of a 40 key string to the user after creation and send that back in addition with a user when we authenticate.  This key could then be sent with ajax requests in either the header or as a parameter for creating/acessing resources that need authentication/authorization.
