### PR TITLE
Finally got renderTemplate() to work

### DIFF
--- a/app/assets/javascripts/routes/terms/terms_index_route.js.coffee
+++ b/app/assets/javascripts/routes/terms/terms_index_route.js.coffee
@@ -15,4 +15,17 @@ YJ.TermsIndexRoute = Ember.Route.extend(
     controller.retrieveAllTerms()
   )
 
+  # This method isn't necessary at all because it's covered by the naming convention,
+  # but if you get it wrong, it's a 'pita' to figure out.
+  renderTemplate: ->
+    # This works.
+#    @render(controller: 'terms.index')
+
+    # This also works:
+    @render('terms.index')
+
+    # These invokations silently break bindings and its a 'pita' to track down:
+#    @render(controller: 'terms')
+#    @render('terms')
+
 )


### PR DESCRIPTION
@tyreepace, @Andrewmp1 

(sigh)

`renderTemplate()` does not break bindings unless you mess up on the argument you use.

See the variations on what works and what doesn't in the file I changed.

The problem all along is that we didn't specify the path correctly.  We should have specified 'terms.index'
